### PR TITLE
add empty alt attribute to sizer component

### DIFF
--- a/src/Image/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/Image/__tests__/__snapshots__/index.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`Image not visible renders the blur-up thumb 1`] = `
     }
   >
     <img
+      role="presentation"
       src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3NTAiIGhlaWdodD0iNDIxIj48L3N2Zz4="
       style={
         Object {
@@ -85,6 +86,7 @@ exports[`Image visible image loaded shows the image 1`] = `
     }
   >
     <img
+      role="presentation"
       src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3NTAiIGhlaWdodD0iNDIxIj48L3N2Zz4="
       style={
         Object {
@@ -173,6 +175,7 @@ exports[`Image visible renders the image 1`] = `
     }
   >
     <img
+      role="presentation"
       src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3NTAiIGhlaWdodD0iNDIxIj48L3N2Zz4="
       style={
         Object {

--- a/src/Image/index.tsx
+++ b/src/Image/index.tsx
@@ -155,6 +155,7 @@ export const Image: React.FC<ImagePropTypes> = function ({
         ...pictureStyle,
       }}
       src={`data:image/svg+xml;base64,${universalBtoa(svg)}`}
+      alt=""
     />
   );
 

--- a/src/Image/index.tsx
+++ b/src/Image/index.tsx
@@ -155,7 +155,7 @@ export const Image: React.FC<ImagePropTypes> = function ({
         ...pictureStyle,
       }}
       src={`data:image/svg+xml;base64,${universalBtoa(svg)}`}
-      alt=""
+      role="presentation"
     />
   );
 


### PR DESCRIPTION
Idea to fix #10 by rendering it as decorative with an empty alt-attribute