### PR TITLE
Make sure favicon keys are different in renderMetaTags

### DIFF
--- a/src/Seo/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/Seo/__tests__/__snapshots__/index.test.tsx.snap
@@ -17,5 +17,19 @@ exports[`renderMetaTags generates an array of meta tags 1`] = `
     key="meta-twitter:title"
     name="twitter:title"
   />
+  <link
+    href="https://example.org/favicon.png?h=16&w=16"
+    key="link-icon-16x16"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />
+  <link
+    href="https://example.org/favicon.png?h=32&w=32"
+    key="link-icon-32x32"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />
 </head>
 `;

--- a/src/Seo/__tests__/index.test.tsx
+++ b/src/Seo/__tests__/index.test.tsx
@@ -23,6 +23,26 @@ const metaTags: ToMetaTagsType = [
     },
     content: null,
     tag: "meta"
+  },
+  {
+    attributes: {
+      sizes: "16x16",
+      type: "image/png",
+      rel: "icon",
+      href: "https://example.org/favicon.png?h=16&w=16"
+    },
+    content: null,
+    tag: "link"
+  },
+  {
+    attributes: {
+      sizes: "32x32",
+      type: "image/png",
+      rel: "icon",
+      href: "https://example.org/favicon.png?h=32&w=32"
+    },
+    content: null,
+    tag: "link"
   }
 ];
 
@@ -45,6 +65,8 @@ describe("renderMetaTagsToString", () => {
       '<title>A new Media Area is online! - DatoCMS</title>',
       '<meta property="og:title" content="A new Media Area is online!" />',
       '<meta name="twitter:title" content="A new Media Area is online!" />',
+      '<link sizes="16x16" type="image/png" rel="icon" href="https://example.org/favicon.png?h=16&w=16" />',
+      '<link sizes="32x32" type="image/png" rel="icon" href="https://example.org/favicon.png?h=32&w=32" />'
     ].join("\n"));
   });
 });

--- a/src/Seo/index.tsx
+++ b/src/Seo/index.tsx
@@ -20,6 +20,14 @@ export const renderMetaTags = function (data: SeoMetaTagType[]): JSX.Element[] {
       key.push(attributes.name);
     }
 
+    if (attributes && "rel" in attributes) {
+      key.push(attributes.rel);
+    }
+
+    if (attributes && "sizes" in attributes) {
+      key.push(attributes.sizes);
+    }
+
     const Tag = tag as "meta" | "title";
 
     return (

--- a/src/Seo/index.tsx
+++ b/src/Seo/index.tsx
@@ -28,7 +28,7 @@ export const renderMetaTags = function (data: SeoMetaTagType[]): JSX.Element[] {
       key.push(attributes.sizes);
     }
 
-    const Tag = tag as "meta" | "title";
+    const Tag = tag as "meta" | "title" | "link";
 
     return (
       <Tag key={key.join("-")} {...attributes}>


### PR DESCRIPTION
There was an incompatibility with React (and Next.js specifically) where
the key generated for the favicon tags would be the same for each
variant, therefore only the last size would get rendered.

This adds the `rel` and `sizes` attributes to the key, when available.