### PR TITLE
img — empty `alt`

### DIFF
--- a/src/Image/index.tsx
+++ b/src/Image/index.tsx
@@ -228,7 +228,7 @@ export const Image: React.FC<ImagePropTypes> = function ({
           {data.src && (
             <img
               src={data.src}
-              alt={data.alt}
+              alt={data.alt ?? ''}
               title={data.title}
               className={pictureClassName}
               style={{ ...absolutePositioning, ...pictureStyle }}


### PR DESCRIPTION
It's better for accessibility to add an empty alt attribute instead of none:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-alt
This resolves a lot of lighthouse error messages.