### PR TITLE
Add back empty `alt`

### DIFF
--- a/src/Image/index.tsx
+++ b/src/Image/index.tsx
@@ -244,7 +244,7 @@ export const Image = forwardRef<HTMLDivElement, ImagePropTypes>(
             {data.src && (
               <img
                 src={data.src}
-                alt={data.alt}
+                alt={data.alt ?? ''}
                 title={data.title}
                 onLoad={handleLoad}
                 className={pictureClassName}


### PR DESCRIPTION
Seems like this fix had been overwritten.
It's necessary for screenreaders to provide a `alt` attribute (even when it's empty).