### PR TITLE
Make webpack builds use esm/module file

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {
-    ".": "./dist/cjs/index.js",
+    ".": {
+      "module": "./dist/esm/index.js",
+      "default": "./dist/cjs/index.js"
+    },
     "./seo": "./dist/cjs/Seo/index.js",
     "./image": "./dist/cjs/Image/index.js",
     "./structured-text": "./dist/cjs/StructuredText/index.js",


### PR DESCRIPTION
It seems like if exports is present, webpack (using 5.76.1) uses that instead of the module field. I think this change is pretty safe since it still defaults to commonjs/cjs for basic imports.

With this change my webpack builds (with standard, I think, config and target = undefined) and importing like `import { StructuredText } from 'react-datocms'` just includes the StructuredText component 5.43KB, otherwise it includes everything (?) ~24.28KB.

When trying to understand how webpack chooses what to import this page was useful to me https://webpack.js.org/guides/package-exports/#general-syntax  It states this:

> The exports field in the package.json of a package allows to declare which module should be used when using module requests like import "package" or import "package/sub/path".

Maybe this means that `exports` is only used when doing module/esm imports and maybe it then would make sense to use the esm/module by default?

like:
```
  "exports": {
    ".": "./dist/esm/index.js",
    "./seo": "./dist/esm/Seo/index.js",
    "./image": "./dist/esm/Image/index.js",
    "./structured-text": "./dist/esm/StructuredText/index.js",
    "./use-query-subscription": "./dist/esm/useQuerySubscription/index.js",
    "./use-site-search": "./dist/esm/useSiteSearch/index.js"
  },
```

UPDATE:

With the current settings it seems that importing explicitly from /dist/esm/index.js isn't allowed (in webpack), when I try to I get this error:
```
Module not found: Error: Package path ./dist/esm/index.js is not exported from package /Users/trondfroding/code/web/node_modules/react-datocms (see exports field in /Users/trondfroding/code/web/node_modules/react-datocms/package.json)

webpack compiled with 1 error
```