### PR TITLE
Add null check for blog posts without images

### DIFF
--- a/examples/images-and-seo/next/pages/index.js
+++ b/examples/images-and-seo/next/pages/index.js
@@ -34,11 +34,13 @@ const App = ({ data }) => {
         </div>
         {data.blogPosts.map((blogPost) => (
           <article key={blogPost.id} className="blogPost">
-            <Image
-              className="blogPost-image"
-              fadeInDuration={1000}
-              data={blogPost.coverImage.responsiveImage}
-            />
+              { blogPost.coverImage?.responsiveImage &&
+                <Image
+                  className="blogPost-image"
+                  fadeInDuration={1000}
+                  data={blogPost.coverImage.responsiveImage}
+                />
+              }
             <h6 className="blogPost-title">
               <a
                 href={`https://www.datocms.com/blog/${blogPost.slug}`}


### PR DESCRIPTION
This fixes an issue with the `next` example where blog posts with no images will crash the app and cause the page to fail to load.

## Before
![image](https://github.com/datocms/react-datocms/assets/11964962/b0e7a2ae-fed1-4c27-892a-0c50649cb0de)


## After
![image](https://github.com/datocms/react-datocms/assets/11964962/c15117aa-d322-437c-9569-f133ca0644f0)
