### PR TITLE
Move stega util exports out of custom client hook so they can work in RSCs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,8 @@ export * from './useVideoPlayer/index.js';
 
 export * from './ContentLink/index.js';
 export * from './useContentLink/index.js';
+
+// Re-export types and utilities from @datocms/content-link for convenience
+// Do NOT put these in a 'use client' component or custom hook or they won't run in RSCs correctly
+export { decodeStega, revealStega, stripStega } from '@datocms/content-link';
+export type { Controller } from '@datocms/content-link';

--- a/src/useContentLink/index.ts
+++ b/src/useContentLink/index.ts
@@ -1,11 +1,7 @@
 'use client';
 
 import { type Controller, createController } from '@datocms/content-link';
-import { useCallback, useEffect, useRef } from 'react';
-
-// Re-export types and utilities from @datocms/content-link for convenience
-export { decodeStega, revealStega, stripStega } from '@datocms/content-link';
-export type { Controller } from '@datocms/content-link';
+import { type RefObject, useCallback, useEffect, useRef } from 'react';
 
 export type UseContentLinkOptions = {
   /**
@@ -26,7 +22,7 @@ export type UseContentLinkOptions = {
   /** Callback when Web Previews plugin requests navigation */
   onNavigateTo?: (path: string) => void;
   /** Ref to limit scanning to this root instead of document */
-  root?: React.RefObject<HTMLElement>;
+  root?: RefObject<HTMLElement>;
   /**
    * Hue (0–359) of the overlay accent color.
    * @default 17 (orange)


### PR DESCRIPTION
Having the `stripStega()` etc. utilities exported from the `useContentLink.tsx` hook was breaking their usage in React Server Components.

This just moves them into src/index.ts.